### PR TITLE
Implement asynchronous polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Currently supported:
 - Socket options (`setOption(int option, String value)`)
 - Receiving multipart messages (`ZMessage`)
 - Topic subscription for `sub` sockets (`subscribe(String topic)` & `unsubscribe(String topic)`)
+- Asynchronous polling using `ZPoller`
 
 
 ## Getting started

--- a/lib/src/bindings.dart
+++ b/lib/src/bindings.dart
@@ -38,12 +38,10 @@ class ZMQPollItem extends Struct {
 typedef ZmqHasNative = Int32 Function(Pointer<Utf8> capability);
 typedef ZmqHasDart = int Function(Pointer<Utf8> capability);
 
-typedef ZmqBindNative = Int32 Function(
-    ZMQSocket socket, Pointer<Utf8> endpoint);
+typedef ZmqBindNative = Int32 Function(ZMQSocket socket, Pointer<Utf8> endpoint);
 typedef ZmqBindDart = int Function(ZMQSocket socket, Pointer<Utf8> endpoint);
 
-typedef ZmqConnectNative = Int32 Function(
-    ZMQSocket socket, Pointer<Utf8> endpoint);
+typedef ZmqConnectNative = Int32 Function(ZMQSocket socket, Pointer<Utf8> endpoint);
 typedef ZmqConnectDart = int Function(ZMQSocket socket, Pointer<Utf8> endpoint);
 
 typedef ZmqErrnoNative = Int32 Function();
@@ -62,24 +60,20 @@ typedef ZmqPollerNewDart = ZMQPoller Function();
 typedef ZmqPollerDestroyNative = Int32 Function(Pointer<ZMQPoller> poller);
 typedef ZmqPollerDestroyDart = int Function(Pointer<ZMQPoller> poller);
 
-typedef ZmqPollerAddNative = Int32 Function(
-    ZMQPoller poller, ZMQSocket socket, Pointer<Void> userData, Int16 events);
-typedef ZmqPollerAddDart = int Function(
-    ZMQPoller poller, ZMQSocket socket, Pointer<Void> userData, int events);
+typedef ZmqPollerAddNative = Int32 Function(ZMQPoller poller, ZMQSocket socket, Pointer<Void> userData, Int16 events);
+typedef ZmqPollerAddDart = int Function(ZMQPoller poller, ZMQSocket socket, Pointer<Void> userData, int events);
 
-typedef ZmqPollerRemoveNative = Int32 Function(
-    ZMQPoller poller, ZMQSocket sockeft);
+typedef ZmqPollerModifyNative = Int32 Function(ZMQPoller poller, ZMQSocket socket, Int16 events);
+typedef ZmqPollerModifyDart = int Function(ZMQPoller poller, ZMQSocket socket, int events);
+
+typedef ZmqPollerRemoveNative = Int32 Function(ZMQPoller poller, ZMQSocket sockeft);
 typedef ZmqPollerRemoveDart = int Function(ZMQPoller poller, ZMQSocket socket);
 
-typedef ZmqPollNative = Int32 Function(
-    Pointer<ZMQPollItem> items, Int32 nitems, Int64 timeout);
-typedef ZmqPollDart = int Function(
-    Pointer<ZMQPollItem> items, int nitems, int timeout);
+typedef ZmqPollNative = Int32 Function(Pointer<ZMQPollItem> items, Int32 nitems, Int64 timeout);
+typedef ZmqPollDart = int Function(Pointer<ZMQPollItem> items, int nitems, int timeout);
 
-typedef ZmqPollerWaitAllNative = Int32 Function(ZMQPoller poller,
-    Pointer<ZMQPollerEvent> events, Int32 count, Int64 timeout);
-typedef ZmqPollerWaitAllDart = int Function(
-    ZMQPoller poller, Pointer<ZMQPollerEvent> events, int count, int timeout);
+typedef ZmqPollerWaitAllNative = Int32 Function(ZMQPoller poller, Pointer<ZMQPollerEvent> events, Int32 count, Int64 timeout);
+typedef ZmqPollerWaitAllDart = int Function(ZMQPoller poller, Pointer<ZMQPollerEvent> events, int count, int timeout);
 
 // Messages
 typedef ZmqMsgInitNative = Int32 Function(ZMQMessage message);
@@ -91,10 +85,8 @@ typedef ZmqMsgSizeDart = int Function(ZMQMessage message);
 typedef ZmqMsgDataNative = Pointer<Void> Function(ZMQMessage message);
 typedef ZmqMsgDataDart = Pointer<Void> Function(ZMQMessage message);
 
-typedef ZmqMsgRecvNative = Int32 Function(
-    ZMQMessage msg, ZMQSocket socket, Int32 flags);
-typedef ZmqMsgRecvDart = int Function(
-    ZMQMessage msg, ZMQSocket socket, int flags);
+typedef ZmqMsgRecvNative = Int32 Function(ZMQMessage msg, ZMQSocket socket, Int32 flags);
+typedef ZmqMsgRecvDart = int Function(ZMQMessage msg, ZMQSocket socket, int flags);
 
 typedef ZmqMsgMoreNative = Int32 Function(ZMQMessage message);
 typedef ZmqMsgMoreDart = int Function(ZMQMessage message);
@@ -108,15 +100,11 @@ typedef ZmqSocketDart = ZMQSocket Function(ZMQContext context, int type);
 typedef ZmqCloseNative = Int32 Function(ZMQSocket socket);
 typedef ZmqCloseDart = int Function(ZMQSocket socket);
 
-typedef ZmqSendNative = Int32 Function(
-    ZMQSocket socket, Pointer<Void> buffer, IntPtr size, Int32 flags);
-typedef ZmqSendDart = int Function(
-    ZMQSocket socket, Pointer<Void> buffer, int size, int flags);
+typedef ZmqSendNative = Int32 Function(ZMQSocket socket, Pointer<Void> buffer, IntPtr size, Int32 flags);
+typedef ZmqSendDart = int Function(ZMQSocket socket, Pointer<Void> buffer, int size, int flags);
 
-typedef ZmqsetsockoptNative = Int32 Function(
-    ZMQSocket socket, Int32 option, Pointer<Uint8> optval, IntPtr optvallen);
-typedef ZmqSetsockoptDart = int Function(
-    ZMQSocket socket, int option, Pointer<Uint8> optval, int optvallen);
+typedef ZmqsetsockoptNative = Int32 Function(ZMQSocket socket, Int32 option, Pointer<Uint8> optval, IntPtr optvallen);
+typedef ZmqSetsockoptDart = int Function(ZMQSocket socket, int option, Pointer<Uint8> optval, int optvallen);
 
 class ZMQBindings {
   late final DynamicLibrary library;
@@ -137,6 +125,7 @@ class ZMQBindings {
   late final ZmqPollerNewDart zmq_poller_new;
   late final ZmqPollerDestroyDart zmq_poller_destroy;
   late final ZmqPollerAddDart zmq_poller_add;
+  late final ZmqPollerModifyDart zmq_poller_modify;
   late final ZmqPollerRemoveDart zmq_poller_remove;
   late final ZmqPollDart zmq_poll;
   late final ZmqPollerWaitAllDart zmq_poller_wait_all;
@@ -156,9 +145,7 @@ class ZMQBindings {
   }
 
   void _initLibrary() {
-    final loaded = _loadLibrary('zmq') ||
-        _loadLibrary('libzmq') ||
-        _loadLibrary('libzmq-v142-mt-4_3_5');
+    final loaded = _loadLibrary('zmq') || _loadLibrary('libzmq') || _loadLibrary('libzmq-v142-mt-4_3_5');
     if (!loaded) {
       throw Exception('Could not load any zeromq library');
     }
@@ -166,53 +153,32 @@ class ZMQBindings {
 
   void _lookupFunctions() {
     zmq_has = library.lookupFunction<ZmqHasNative, ZmqHasDart>('zmq_has');
-    zmq_errno =
-        library.lookupFunction<ZmqErrnoNative, ZmqErrnoDart>('zmq_errno');
+    zmq_errno = library.lookupFunction<ZmqErrnoNative, ZmqErrnoDart>('zmq_errno');
     zmq_bind = library.lookupFunction<ZmqBindNative, ZmqBindDart>('zmq_bind');
-    zmq_connect =
-        library.lookupFunction<ZmqConnectNative, ZmqConnectDart>('zmq_connect');
-    zmq_ctx_new =
-        library.lookupFunction<ZmqCtxNewNative, ZmqCtxNewDart>('zmq_ctx_new');
-    zmq_ctx_term = library
-        .lookupFunction<ZmqCtxTermNative, ZmqCtxTermDart>('zmq_ctx_term');
-    zmq_socket =
-        library.lookupFunction<ZmqSocketNative, ZmqSocketDart>('zmq_socket');
-    zmq_close =
-        library.lookupFunction<ZmqCloseNative, ZmqCloseDart>('zmq_close');
+    zmq_connect = library.lookupFunction<ZmqConnectNative, ZmqConnectDart>('zmq_connect');
+    zmq_ctx_new = library.lookupFunction<ZmqCtxNewNative, ZmqCtxNewDart>('zmq_ctx_new');
+    zmq_ctx_term = library.lookupFunction<ZmqCtxTermNative, ZmqCtxTermDart>('zmq_ctx_term');
+    zmq_socket = library.lookupFunction<ZmqSocketNative, ZmqSocketDart>('zmq_socket');
+    zmq_close = library.lookupFunction<ZmqCloseNative, ZmqCloseDart>('zmq_close');
 
     zmq_send = library.lookupFunction<ZmqSendNative, ZmqSendDart>('zmq_send');
 
-    zmq_poller_new = library
-        .lookupFunction<ZmqPollerNewNative, ZmqPollerNewDart>('zmq_poller_new');
-    zmq_poller_destroy =
-        library.lookupFunction<ZmqPollerDestroyNative, ZmqPollerDestroyDart>(
-            'zmq_poller_destroy');
-    zmq_poller_add = library
-        .lookupFunction<ZmqPollerAddNative, ZmqPollerAddDart>('zmq_poller_add');
-    zmq_poller_remove =
-        library.lookupFunction<ZmqPollerRemoveNative, ZmqPollerRemoveDart>(
-            'zmq_poller_remove');
+    zmq_poller_new = library.lookupFunction<ZmqPollerNewNative, ZmqPollerNewDart>('zmq_poller_new');
+    zmq_poller_destroy = library.lookupFunction<ZmqPollerDestroyNative, ZmqPollerDestroyDart>('zmq_poller_destroy');
+    zmq_poller_add = library.lookupFunction<ZmqPollerAddNative, ZmqPollerAddDart>('zmq_poller_add');
+    zmq_poller_modify = library.lookupFunction<ZmqPollerModifyNative, ZmqPollerModifyDart>('zmq_poller_modify');
+    zmq_poller_remove = library.lookupFunction<ZmqPollerRemoveNative, ZmqPollerRemoveDart>('zmq_poller_remove');
     zmq_poll = library.lookupFunction<ZmqPollNative, ZmqPollDart>('zmq_poll');
-    zmq_poller_wait_all =
-        library.lookupFunction<ZmqPollerWaitAllNative, ZmqPollerWaitAllDart>(
-            'zmq_poller_wait_all');
+    zmq_poller_wait_all = library.lookupFunction<ZmqPollerWaitAllNative, ZmqPollerWaitAllDart>('zmq_poller_wait_all');
 
-    zmq_msg_init = library
-        .lookupFunction<ZmqMsgInitNative, ZmqMsgInitDart>('zmq_msg_init');
-    zmq_msg_close = library
-        .lookupFunction<ZmqMsgCloseNative, ZmqMsgCloseDart>('zmq_msg_close');
-    zmq_msg_size = library
-        .lookupFunction<ZmqMsgSizeNative, ZmqMsgSizeDart>('zmq_msg_size');
-    zmq_msg_data = library
-        .lookupFunction<ZmqMsgDataNative, ZmqMsgDataDart>('zmq_msg_data');
-    zmq_msg_recv = library
-        .lookupFunction<ZmqMsgRecvNative, ZmqMsgRecvDart>('zmq_msg_recv');
-    zmq_msg_more = library
-        .lookupFunction<ZmqMsgMoreNative, ZmqMsgMoreDart>('zmq_msg_more');
+    zmq_msg_init = library.lookupFunction<ZmqMsgInitNative, ZmqMsgInitDart>('zmq_msg_init');
+    zmq_msg_close = library.lookupFunction<ZmqMsgCloseNative, ZmqMsgCloseDart>('zmq_msg_close');
+    zmq_msg_size = library.lookupFunction<ZmqMsgSizeNative, ZmqMsgSizeDart>('zmq_msg_size');
+    zmq_msg_data = library.lookupFunction<ZmqMsgDataNative, ZmqMsgDataDart>('zmq_msg_data');
+    zmq_msg_recv = library.lookupFunction<ZmqMsgRecvNative, ZmqMsgRecvDart>('zmq_msg_recv');
+    zmq_msg_more = library.lookupFunction<ZmqMsgMoreNative, ZmqMsgMoreDart>('zmq_msg_more');
 
-    zmq_setsockopt =
-        library.lookupFunction<ZmqsetsockoptNative, ZmqSetsockoptDart>(
-            'zmq_setsockopt');
+    zmq_setsockopt = library.lookupFunction<ZmqsetsockoptNative, ZmqSetsockoptDart>('zmq_setsockopt');
   }
 
   bool _loadLibrary(final String name) {
@@ -239,8 +205,7 @@ class ZMQBindings {
     throw Exception('Platform not implemented');
   }
 
-  DynamicLibrary _dlOpenPlatformSpecific(final String name,
-      {final String? path}) {
+  DynamicLibrary _dlOpenPlatformSpecific(final String name, {final String? path}) {
     String fullPath = _platformPath(name, path: path);
     return DynamicLibrary.open(fullPath);
   }

--- a/lib/src/poller.dart
+++ b/lib/src/poller.dart
@@ -1,0 +1,186 @@
+import 'dart:ffi';
+import 'dart:isolate';
+import 'package:ffi/ffi.dart';
+
+import 'bindings.dart';
+
+part of 'zeromq.dart';
+
+enum _PollingMessage {
+  stop,
+  send_port,
+  socket_count,
+  polling_result,
+  polling_stopped
+}
+
+const int _pollingTimeoutMilliseconds = 100;
+
+void _poll(List<Object> arguments) async {
+    SendPort sender = arguments[0] as SendPort;
+    int socketCount = arguments[1] as int;
+    ZMQPoller poller = ZMQPoller.fromAddress(arguments[2] as int);
+
+    bool run = true;
+    ReceivePort receiver = ReceivePort();
+    sender.send([_PollingMessage.send_port, receiver.sendPort]);
+
+    receiver.listen((msg) {
+      var message = msg as List<Object>;
+
+      switch (message[0] as _PollingMessage) {
+        case _PollingMessage.socket_count:
+          socketCount = message[1] as int;
+        break;
+        case _PollingMessage.stop:
+          run = false;
+        break;
+        default:break;
+      }
+
+    });
+
+    while(run) {
+      final pollerEvents = malloc.allocate<ZMQPollerEvent>(sizeOf<ZMQPollerEvent>() * socketCount);
+      final availableEventCount = _bindings.zmq_poller_wait_all(poller, pollerEvents, socketCount, _pollingTimeoutMilliseconds);
+
+      List<int> list = [];
+      for (int i = 0; i < availableEventCount; i++) {
+        list.add(pollerEvents[i].socket.address);
+      }
+
+      if (availableEventCount > 0) {        
+        sender.send([_PollingMessage.polling_result, availableEventCount, list]);
+      }
+      else {
+        sender.send([_PollingMessage.polling_result, 0]);
+      }
+      malloc.free(pollerEvents);
+      await Future.delayed(Duration.zero);
+
+    }
+
+    sender.send([_PollingMessage.polling_stopped]);
+
+    receiver.close();
+}
+
+class ZPoller {
+  final ZMQPoller _poller = _bindings.zmq_poller_new();
+  final Map<ZMQSocket, ZSocket> _sockets = {};
+  final ReceivePort _receiver = ReceivePort();
+  SendPort? _sender;
+  Completer? _completer;
+
+  ZPoller() {
+    _receiver.listen(_pollListener);
+  }
+
+  void add(ZSocket socket, int events) {
+    _bindings.zmq_poller_add(_poller, socket._socket, nullptr, events);
+    _sockets[socket._socket] = socket;
+    _sender?.send(_sockets.length);
+  }
+
+  void remove(ZSocket socket) {
+    _bindings.zmq_poller_remove(_poller, socket._socket);
+    _sockets.remove(socket._socket);
+    _sender?.send(_sockets.length);
+  }
+
+  void modify(ZSocket socket, int events) {
+    _bindings.zmq_poller_modify(_poller, socket._socket, events);
+  }
+
+  void start() {
+    Isolate.spawn(_poll, [_receiver.sendPort, _sockets.length, _poller.address]); 
+  }
+
+  void stop() {
+    _sender?.send([_PollingMessage.stop]);
+    _sender = null;
+  }
+
+  Future<void> shutdown() async {
+    _sender?.send([_PollingMessage.stop]);
+    _completer = Completer();
+
+    // if send port is null that means the _poll isolate as never spawned, so skip this
+    if (_sender != null) {
+      await _completer?.future;
+    }
+
+    _receiver.close();
+    _sockets.clear();
+    Pointer<ZMQPoller> pollerPointer = malloc.allocate<ZMQPoller>(0);
+    pollerPointer.value = _poller;
+    _bindings.zmq_poller_destroy(pollerPointer);
+    malloc.free(pollerPointer);
+    return;
+  }
+
+  void _pollListener(dynamic message) async {
+    List<Object> response = message as List<Object>;
+  
+    var pollingMessage = response[0] as _PollingMessage;
+
+    switch (response[0] as _PollingMessage) {
+      case _PollingMessage.send_port:
+        _sender = response[1] as SendPort;
+      break;
+
+      case _PollingMessage.polling_stopped:
+        _completer?.complete();
+      break;
+
+      case _PollingMessage.polling_result:
+        int count = response[1] as int;
+
+        if (count > 0) {
+
+          var pollerEvents = response[2] as List<int>;        
+
+          final msg = _allocateMessage();
+          var rc = _bindings.zmq_msg_init(msg); // rc == 0
+          _checkReturnCode(rc);
+
+          for (var eventIdx = 0; eventIdx < count; ++eventIdx) {
+            final pollerEvent = pollerEvents[eventIdx];
+            ZMQSocket zmqsocket = ZMQSocket.fromAddress(pollerEvents[eventIdx]);
+            ZSocket? socket = _sockets[zmqsocket];
+
+            if (socket == null) {
+              continue;
+            }
+
+            // Receive multiple message parts
+            ZMessage zMessage = ZMessage();
+            bool hasMore = true;
+            while ((rc = _bindings.zmq_msg_recv(msg, socket._socket, ZMQ_DONTWAIT)) > 0) {
+              final data = _bindings.zmq_msg_data(msg).cast<Uint8>();
+
+              final copyOfData = Uint8List.fromList(data.asTypedList(rc));
+              hasMore = _bindings.zmq_msg_more(msg) != 0;
+
+              zMessage.add(ZFrame(copyOfData, hasMore: hasMore));
+
+              if (!hasMore) {
+                socket._controller.add(zMessage);
+                zMessage = ZMessage();
+              }
+            }
+
+            _checkReturnCode(rc, ignore: [EAGAIN]);
+          }
+
+          rc = _bindings.zmq_msg_close(msg);
+          _checkReturnCode(rc);
+
+          malloc.free(msg);
+        }
+      break;
+
+      default:break;
+    }
+  }
+}

--- a/lib/src/poller.dart
+++ b/lib/src/poller.dart
@@ -6,74 +6,49 @@ import 'bindings.dart';
 
 part of 'zeromq.dart';
 
+/// Internal commands for communication with the polling Isolate
 enum _PollingMessage {
+  /// Request that the Isolate stop polling
   stop,
+
+  /// SendPort from the Isolate so the main thread can communicate
   send_port,
+
+  /// Update the Isolate's socketCount when sockets are added or removed
   socket_count,
+
+  /// Result from the polling Isolate with the polling events
   polling_result,
+
+  /// Indicate that the polling Isolate has ended
   polling_stopped
 }
 
+/// Events types that the ZeroMQ poller will subscribe to
+enum PollingEvent {
+
+  /// Will subscribe to no events - can be updated later with modify()
+  poll_none,
+
+  /// Subscribe to incoming messages - triggered when at least one message can be received
+  poll_in,
+
+  /// Subscribe to outgoing messages - triggered when at least one message can be send
+  poll_out,
+
+  // Subscribe to both income and outgoing messages
+  poll_in_out
+
+  // Note: ZMQ_POLLERR and ZMQ_POLLPRI are not used here as they have no effect on the poller
+  // and are generally not relevant to ZeroMQ sockets
+}
+
+/// Timeout in milliseconds for the ZeroMQ poller - the poller will wait up to this timeout
+/// before returning. The poller returns as soon as data is available (i.e. potentially before
+/// this timeout)
 const int _pollingTimeoutMilliseconds = 100;
 
-void _poll(List<Object> arguments) async {
-    SendPort sender = arguments[0] as SendPort;
-    int socketCount = arguments[1] as int;
-    ZMQPoller poller = ZMQPoller.fromAddress(arguments[2] as int);
-
-    bool run = true;
-    ReceivePort receiver = ReceivePort();
-    sender.send([_PollingMessage.send_port, receiver.sendPort]);
-
-    receiver.listen((msg) {
-      var message = msg as List<Object>;
-
-      switch (message[0] as _PollingMessage) {
-        case _PollingMessage.socket_count:
-          socketCount = message[1] as int;
-        break;
-        case _PollingMessage.stop:
-          run = false;
-        break;
-        default:break;
-      }
-
-    });
-
-    while(run) {
-      final pollerEvents = malloc.allocate<ZMQPollerEvent>(sizeOf<ZMQPollerEvent>() * socketCount);
-      final availableEventCount = _bindings.zmq_poller_wait_all(poller, pollerEvents, socketCount, _pollingTimeoutMilliseconds);
-
-      List<int> list = [];
-      for (int i = 0; i < availableEventCount; i++) {
-        list.add(pollerEvents[i].socket.address);
-      }
-
-      if (availableEventCount > 0) {        
-        sender.send([_PollingMessage.polling_result, availableEventCount, list]);
-      }
-      else {
-        sender.send([_PollingMessage.polling_result, 0]);
-      }
-      malloc.free(pollerEvents);
-      await Future.delayed(Duration.zero);
-
-    }
-
-    sender.send([_PollingMessage.polling_stopped]);
-
-    receiver.close();
-}
-
-enum PollingEvent {
-  poll_none,
-  poll_in,
-  poll_out,
-  poll_in_out,
-  poll_err,
-  poll_pri
-}
-
+/// Convert the PollingEvent enum to the appropriate ZeroMQ flag so it can be sent to the poller
 int _pollingEventToInt(PollingEvent type) {
   switch (type) {
     case PollingEvent.poll_none:
@@ -84,56 +59,162 @@ int _pollingEventToInt(PollingEvent type) {
       return ZMQ_POLLOUT;
     case PollingEvent.poll_in_out:
       return ZMQ_POLLIN | ZMQ_POLLOUT;
-    case PollingEvent.poll_err:
-      return ZMQ_POLLERR;
-    case PollingEvent.poll_pri:
-      return ZMQ_POLLPRI;
   }
 }
 
+/// Entry point for the polling Isolate. This will run until commanded to stop by the main thread
+/// Three arguments are sent as a List<Object>: a SendPort, the current socket count, and the
+/// address of the ZeroMQ poller object. The SendPort is used along with the local ReceivePort
+/// to communicate with the main thread. The very first message to the SendPort must be the corresponding
+/// ReceivePort to the local SendPort so the main thread can communicate with this Isolate
+/// 
+/// The socket count can be updated as the poller is running. When add() or remove() is called, a 
+/// message will be sent to this Isolate and the count will be updated.
+/// 
+/// Since pointers can not be sent directly to Isolates, the address is passed and the pointer
+/// to the ZeroMQ poller is reconstructed.
+/// 
+/// Likewise, when messages are received through the poller, the addresses of the appropriate
+/// sockets are sent to the main thread and reconstructed there
+void _poll(List<Object> arguments) async {
+
+  // Reconstruct the  
+  SendPort sender = arguments[0] as SendPort;
+  int socketCount = arguments[1] as int;
+  ZMQPoller poller = ZMQPoller.fromAddress(arguments[2] as int);
+
+  // Create a ReceivedPort to message the outside world
+  ReceivePort receiver = ReceivePort();
+
+  // Listen handler for the receive port
+  receiver.listen((msg) {
+    var message = msg as List<Object>;
+
+    switch (message[0] as _PollingMessage) {
+
+      // Update the socket count - this determines how many ZMQPollerEvents are alloc'd
+      case _PollingMessage.socket_count:
+        socketCount = message[1] as int;
+      break;
+
+      // Stop the polling thread and exit this Isolate
+      case _PollingMessage.stop:
+        run = false;
+      break;
+      default:break;
+    }
+
+  });
+
+  // Immediately send the corrsponding SendPort so the main thread can start communicating
+  sender.send([_PollingMessage.send_port, receiver.sendPort]);
+
+  // Flag to run the poller loop - will only be set to false by a message from the main thread
+  bool run = true;
+
+  while(run) {
+    // Allocate the appropriate number of ZMQPollerEvents based on how many sockets have been added to the poller
+    // This is done every loop to account for the possibility of socketCount changing
+    final pollerEvents = malloc.allocate<ZMQPollerEvent>(sizeOf<ZMQPollerEvent>() * socketCount);
+
+    // Poll. This will block up to the _pollingTimeoutMilliseconds, but may return sooner if data is available
+    final availableEventCount = _bindings.zmq_poller_wait_all(poller, pollerEvents, socketCount, _pollingTimeoutMilliseconds);
+
+    // Produce a list with the addresses of the sockets that have data available
+    List<int> list = [];
+    for (int i = 0; i < availableEventCount; i++) {
+      list.add(pollerEvents[i].socket.address);
+    }
+
+    // Send the socket addresses. If there are not sockets with data, just send the return value of the poll function
+    if (availableEventCount > 0) {        
+      sender.send([_PollingMessage.polling_result, availableEventCount, list]);
+    }
+    else {
+      sender.send([_PollingMessage.polling_result, availableEventCount]);
+    }
+
+    // Free the memory allocated for the ZMQPollerEvents
+    malloc.free(pollerEvents);
+
+    // Give up the time slice to let the main thread run
+    await Future.delayed(Duration.zero);
+  }
+
+  // Let the main thread know we have finished and close our ReceivePort
+  sender.send([_PollingMessage.polling_stopped]);
+  receiver.close();
+}
+
+/// Wrapper of the zmq_poller class
 class ZPoller {
+  // The ZeroMQ poller 
   final ZMQPoller _poller = _bindings.zmq_poller_new();
+
+  // Map our sockets to the underlying ZeroMQ sockets
   final Map<ZMQSocket, ZSocket> _sockets = {};
+
+  // Used to communicate with the poller Isolate
   final ReceivePort _receiver = ReceivePort();
+
+  // Used to communicate with the poller Isolate
   SendPort? _sender;
-  Completer? _completer;
+
+  // Used to wait until the poller Isolate has stopped
+  Completer? _shutdownCompleter;
 
   ZPoller() {
+    // Attach our listener to receive messages from the poller Isolate
     _receiver.listen(_pollListener);
   }
 
+  /// Adds [socket] to the ZeroMQ poller. Use [events] to subscribe to socket events. 
+  /// Events can be added or updated later by calling modify()
   void add(ZSocket socket, PollingEvent events) {
     _bindings.zmq_poller_add(_poller, socket._socket, nullptr, _pollingEventToInt(events));
     _sockets[socket._socket] = socket;
     _sender?.send(_sockets.length);
   }
 
+  /// Removes [socket] from the ZeroMQ poller. There is no effect if the socket is not
+  /// currently registered
   void remove(ZSocket socket) {
-    _bindings.zmq_poller_remove(_poller, socket._socket);
-    _sockets.remove(socket._socket);
-    _sender?.send(_sockets.length);
+    if (_sockets.containsKey(socket._socket)) {
+      _bindings.zmq_poller_remove(_poller, socket._socket);
+      _sockets.remove(socket._socket);
+      _sender?.send(_sockets.length);
+    }
   }
 
+  /// Modify the events associated with [socket] to [events]. There is no effect if the
+  /// socket is not registered.
   void modify(ZSocket socket, PollingEvent events) {
-    _bindings.zmq_poller_modify(_poller, socket._socket, _pollingEventToInt(events));
+    if (_sockets.containsKey(socket._socket)) {
+      _bindings.zmq_poller_modify(_poller, socket._socket, _pollingEventToInt(events));
+    }
   }
 
+  /// Start polling. Polling will happen asynchronously in an Isolate
   void start() {
     Isolate.spawn(_poll, [_receiver.sendPort, _sockets.length, _poller.address]); 
   }
 
+  /// Stop polling. Polling can be restarted with start()
   void stop() {
     _sender?.send([_PollingMessage.stop]);
     _sender = null;
   }
 
+  /// Shutdown the poller. This will unregister all sockets and free the ZeroMQ poller.
+  /// Polling should NOT be started again on this poller after calling shutdown().
+  /// This call should be awaited to ensure the poller Isolate has completely stopped.
   Future<void> shutdown() async {
     _sender?.send([_PollingMessage.stop]);
-    _completer = Completer();
+    _shutdownCompleter = Completer();
 
     // if send port is null that means the _poll isolate as never spawned, so skip this
     if (_sender != null) {
-      await _completer?.future;
+      await _shutdownCompleter?.future;
     }
 
     _receiver.close();
@@ -145,34 +226,40 @@ class ZPoller {
     return;
   }
 
+  /// Listener for the poller Isolate
   void _pollListener(dynamic message) async {
-    List<Object> response = message as List<Object>;
-  
+    // The Isolate will send a List<Object> the first item of which should be a command
+    List<Object> response = message as List<Object>;  
     var pollingMessage = response[0] as _PollingMessage;
 
     switch (response[0] as _PollingMessage) {
+      // Update the SendPort to communicate with the Isolate
       case _PollingMessage.send_port:
         _sender = response[1] as SendPort;
       break;
 
+      // The polling Isolate has finished and shutdown can be completed
       case _PollingMessage.polling_stopped:
-        _completer?.complete();
+        _shutdownCompleter?.complete();
       break;
 
+      // Results of the polling operation
       case _PollingMessage.polling_result:
+        // The number of sockets that have data available
         int count = response[1] as int;
-
         if (count > 0) {
+          // The poller sends a list of socket addresses
+          var polledSocketAddresses = response[2] as List<int>;        
 
-          var pollerEvents = response[2] as List<int>;        
-
+          // Allocate some room for the messages we are about to receive
           final msg = _allocateMessage();
-          var rc = _bindings.zmq_msg_init(msg); // rc == 0
-          _checkReturnCode(rc);
+          var returnCode = _bindings.zmq_msg_init(msg); // rc == 0
+          _checkReturnCode(returnCode);
 
           for (var eventIdx = 0; eventIdx < count; ++eventIdx) {
-            final pollerEvent = pollerEvents[eventIdx];
-            ZMQSocket zmqsocket = ZMQSocket.fromAddress(pollerEvents[eventIdx]);
+            // Get the zmq_socket from the address and see if it matches one of the
+            // registered ZSockets
+            ZMQSocket zmqsocket = ZMQSocket.fromAddress(polledSocketAddresses[eventIdx]);
             ZSocket? socket = _sockets[zmqsocket];
 
             if (socket == null) {
@@ -182,7 +269,7 @@ class ZPoller {
             // Receive multiple message parts
             ZMessage zMessage = ZMessage();
             bool hasMore = true;
-            while ((rc = _bindings.zmq_msg_recv(msg, socket._socket, ZMQ_DONTWAIT)) > 0) {
+            while ((returnCode = _bindings.zmq_msg_recv(msg, socket._socket, ZMQ_DONTWAIT)) > 0) {
               final data = _bindings.zmq_msg_data(msg).cast<Uint8>();
 
               final copyOfData = Uint8List.fromList(data.asTypedList(rc));
@@ -190,18 +277,19 @@ class ZPoller {
 
               zMessage.add(ZFrame(copyOfData, hasMore: hasMore));
 
+              // If that is all the data, give it to the socket's StreamController
               if (!hasMore) {
                 socket._controller.add(zMessage);
                 zMessage = ZMessage();
               }
             }
 
-            _checkReturnCode(rc, ignore: [EAGAIN]);
+            _checkReturnCode(returnCode, ignore: [EAGAIN]);
           }
 
-          rc = _bindings.zmq_msg_close(msg);
-          _checkReturnCode(rc);
-
+          // Free the message that was allocated
+          returnCode = _bindings.zmq_msg_close(msg);
+          _checkReturnCode(returnCode);
           malloc.free(msg);
         }
       break;

--- a/lib/src/zeromq.dart
+++ b/lib/src/zeromq.dart
@@ -196,14 +196,6 @@ enum SocketType {
   stream
 }
 
-abstract class PollingType {
-  static int get pollnone => 0;
-  static int get pollin => ZMQ_POLLIN;
-  static int get pollout => ZMQ_POLLOUT;
-  static int get pollerr => ZMQ_POLLERR;
-  static int get pollpri => ZMQ_POLLPRI;
-}
-
 /// A ZFrame or 'frame' corresponds to one underlying zmq_msg_t in the libzmq code.
 /// When you read a frame from a socket, the [hasMore] member indicates
 /// if the frame is part of an unfinished multi-part message.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartzmq
 description: A simple dart zeromq implementation/wrapper around the libzmq C++ library
-version: 1.0.0-dev.8
+version: 1.0.0-dev.9
 homepage: https://github.com/enwi/dartzmq
 
 environment:


### PR DESCRIPTION
This pull request adds asynchronous polling by way of the ZPoller class which uses an Isolate to call the underlying zmq_poller_wait_all without blocking the main Isolate. Since there is no shared memory between Isolates, the ZMQPoller is created on the main Isolate and passed as a pointer to the polling Isolate. Sockets with available data are passed back to the main Isolate as pointers and matched with the corresponding ZSocket. A ReceivePort/SendPort combo is used to communicate between the two Isolates and shutdown the polling Isolate when required.

The poller runs with a 100ms timeout, but will return as soon as data is available. It should now be possible to receive messages as fast as ZeroMQ will allow. There is currently no implementation of a blocking poll() call. I'm not sure how useful this would really be.

All of the original polling logic has been removed from ZContext in favor of the ZPoller method. However, the underlying Stream method of receiving Messages into ZSockets is still in place as I think this is a good implementation.

I have only tested this on Linux (Ubuntu 20.04), but I plan to test it on at least Windows as well. It would probably be good to add some additional examples to demonstrate general operation, different polling scenarios, and use with various socket types.
